### PR TITLE
fix lack of UUID

### DIFF
--- a/dist/rose-pine-dawn.dconf
+++ b/dist/rose-pine-dawn.dconf
@@ -1,6 +1,9 @@
-[profiles:/:ID]
-visible-name='Rosé Pine Dawn'
+[/]
+default='1d6292b9-4a31-4220-91b5-446cf599d136'
+list=['1d6292b9-4a31-4220-91b5-446cf599d136']
 
+[:1d6292b9-4a31-4220-91b5-446cf599d136]
+visible-name='Rosé Pine Dawn'
 foreground-color='rgb(87,82,121)'
 background-color='rgb(250,244,237)'
 cursor-foreground-color='rgb(87,82,121)'

--- a/dist/rose-pine-moon.dconf
+++ b/dist/rose-pine-moon.dconf
@@ -1,6 +1,9 @@
-[profiles:/:ID]
-visible-name='Rosé Pine Moon'
+[/]
+default='b5bd2ef3-960f-47bb-b163-2db27e9dfa5d'
+list=['b5bd2ef3-960f-47bb-b163-2db27e9dfa5d']
 
+[:b5bd2ef3-960f-47bb-b163-2db27e9dfa5d]
+visible-name='Rosé Pine Moon'
 foreground-color='rgb(224,222,244)'
 background-color='rgb(35,33,54)'
 cursor-foreground-color='rgb(224,222,244)'

--- a/dist/rose-pine.dconf
+++ b/dist/rose-pine.dconf
@@ -1,6 +1,9 @@
-[profiles:/:ID]
-visible-name='Rosé Pine'
+[/]
+default='20973b0f-a7cb-4fdd-bdfc-53cff02014c8'
+list=['20973b0f-a7cb-4fdd-bdfc-53cff02014c8']
 
+[:20973b0f-a7cb-4fdd-bdfc-53cff02014c8]
+visible-name='Rosé Pine'
 foreground-color='rgb(224,222,244)'
 background-color='rgb(25,23,36)'
 cursor-foreground-color='rgb(224,222,244)'


### PR DESCRIPTION
A lack of UUID within the .dconf file caused the installation to fail. I believe this was overlooked when migrating to @rose-pine/build.